### PR TITLE
Added devicetype provisioning script.

### DIFF
--- a/scripts/device_type_provisioning.py
+++ b/scripts/device_type_provisioning.py
@@ -1,0 +1,173 @@
+"""
+This script allows you to import or update exising devicetype record from Netbox's official devicetype-library git repository.
+For more details and instruction, you may check this git repo: https://github.com/kagarcia1618/netbox_custom_script
+
+Note: This scripts has dependency to two other folder found in the directory below:
+- reports/scripts/library
+- reports/scripts/template
+
+Library folder contains the custom class script (device_type_handler.py) to compliment the main script (device_type_provisioning.py).
+Template folder contains the jinja2 template file for generating the script report summary output.
+
+Author: Kenneth Acar Garcia
+Email: kenneth[.]acar[.]garcia[@]gmail[.]com
+"""
+import yaml
+import requests
+from jinja2 import Environment, FileSystemLoader
+from extras.scripts import *
+from dcim.models import DeviceType, Manufacturer, InterfaceTemplate, PowerPortTemplate, ConsolePortTemplate
+from scripts.netbox_script.library.device_type_handler import DeviceTypeHandler
+
+name = 'Import/Update DeviceType Provisioning Script'
+
+class ImportDeviceType(Script):
+
+    class Meta:
+        name = "Import/Update Device Type"
+        description = "Custom script to import or update local Netbox's Device Types from NetBox devicetype-library git repo"
+        commit_default = False
+        field_order = []
+
+    yaml_data = FileVar(
+        label = "Yaml File",
+        description = '''Upload the yaml file with vendor and part number details using the format below:<br>---<br>- vendor: Cisco<br>&nbsp&nbsppart_numbers:<br>&nbsp&nbsp&nbsp&nbsp- N9K-C9332PQ<br>&nbsp&nbsp&nbsp&nbsp- N9K-C92348GC-X<br>- vendor: Arista<br>&nbsp&nbsppart_numbers:<br>&nbsp&nbsp&nbsp&nbsp- DCS-7010T-48'''
+    )
+
+    update_existing_record = BooleanVar(
+        label = "Update Existing Record",
+        description = "Toggle on to update existing device type records for any diff with devicetype-library record",
+        default = False,
+    )
+
+    def run(self, data, commit):
+        try:
+            input_data = yaml.safe_load(data['yaml_data'].read().decode())
+        except (yaml.scanner.ScannerError, yaml.parser.ParserError):
+            self.log_failure("Please check the format of the uploaded yaml file.")
+            return
+        
+        if not isinstance(input_data, list):
+            self.log_failure("Please check the format of the uploaded yaml file.")
+            return
+        
+        in_library_list = [] #Placeholder for user provided partnumber found in devicetype-library git repo
+        not_in_library_list = [] #Placeholder for user provided partnumber not found in devicetype-library git repo
+        imported_devicetype_list = [] #Placeholder for all imported devicetype from devicetype-library git repo
+        updated_devicetype_list = [] #Placeholder for all updated existing devicetype from devicetype-library git repo
+        up_to_date_devicetype_list = [] #Placeholder for all matched existing devicetype from devicetype-library git repo
+        updated_interfacetemplate_list = [] #Placeholder for all updated interfacetemplates of existing devicetype
+        deleted_interfacetemplate_list = [] #Placeholder for all deleted interfacetemplates of existing devicetype
+        imported_interfacetemplate_list = [] #Placeholder for all imported interfacetemplates of existing devicetype and imported devicetype
+        updated_consoleporttemplate_list = [] #Placeholder for all updated consoleporttemplates of existing devicetype
+        deleted_consoleporttemplate_list = [] #Placeholder for all deleted consoleporttemplates of existing devicetype
+        imported_consoleporttemplate_list = [] #Placeholder for all imported consoleporttemplates of existing devicetype and imported devicetype
+        updated_powerporttemplate_list = [] #Placeholder for all updated powerporttemplates of existing devicetype
+        deleted_powerporttemplate_list = [] #Placeholder for all deleted powerporttemplates of existing devicetype
+        imported_powerporttemplate_list = [] #Placeholder for all imported powerporttemplates of existing devicetype and imported devicetype
+
+        #Iterates, searches, validates and categorizes the yaml input data and store them in a different list objects if found or not found
+        for vendor in input_data:
+            if vendor:
+                for part_number in vendor['part_numbers']:
+                    if part_number:
+                        device_type_url = f"https://raw.githubusercontent.com/netbox-community/devicetype-library/master/device-types/{vendor['vendor']}/{part_number}"
+                        try:
+                            get_yml_url = requests.get(f"{device_type_url}.yml")
+                            get_yaml_url = requests.get(f"{device_type_url}.yaml")
+                        except requests.exceptions.ConnectionError as error:
+                            self.log_failure(error)
+                            return
+                        get_url_data = None
+                        for get_data in [get_yml_url, get_yaml_url]:
+                            #Checks if user provided partnumber is found in devicetype-library git repo
+                            if get_data.ok:
+                                get_url_data = get_data
+                        #Store the URL data as DeviceTypeHandler class object in the list object
+                        if get_url_data:
+                            device_type = DeviceTypeHandler(
+                                manufacturer = vendor['vendor'],
+                                part_number = part_number,
+                                yaml_template = get_url_data.text,
+                                update_existing_record = data['update_existing_record'],
+                            )
+                            in_library_list.append(device_type)
+                        else:
+                            device_type = DeviceTypeHandler(
+                                manufacturer = vendor['vendor'],
+                                part_number = part_number,
+                            )
+                            not_in_library_list.append(device_type)
+                    else:
+                        self.log_failure(
+                            f"No part_number found for vendor {vendor['vendor']} in the yaml file."
+                        )
+                        return
+            else:
+                self.log_failure(
+                    f"No vendor name found in one of the vendor list in the yaml file."
+                )
+                return
+
+        #Iterates the list of DeviceTypeHandler objects in found partnumber list
+        for item in in_library_list:
+            #Import or update the DeviceTypeHandler object
+            item.import_record()
+
+            updated_interfacetemplate_list += item.updated_interfacetemplates
+            deleted_interfacetemplate_list += item.deleted_interfacetemplates
+            imported_interfacetemplate_list += item.imported_interfacetemplates
+            updated_consoleporttemplate_list += item.updated_consoleporttemplates
+            deleted_consoleporttemplate_list += item.deleted_consoleporttemplates
+            imported_consoleporttemplate_list += item.imported_consoleporttemplates
+            updated_powerporttemplate_list += item.updated_powerporttemplates
+            deleted_powerporttemplate_list += item.deleted_powerporttemplates
+            imported_powerporttemplate_list += item.imported_powerporttemplates
+
+            operations = [
+                item.updated_interfacetemplates,
+                item.deleted_interfacetemplates,
+                item.imported_interfacetemplates,
+                item.updated_consoleporttemplates,
+                item.deleted_consoleporttemplates,
+                item.imported_consoleporttemplates,
+                item.updated_powerporttemplates,
+                item.deleted_powerporttemplates,
+                item.imported_powerporttemplates,
+            ]
+
+            #Store the DeviceTypeHandler object in a list object depending on the operation mode - import, update or none   
+            if item.operation_mode:
+                imported_devicetype_list.append(item)
+            else:
+                counter = 0
+                for i in operations:
+                        if len(i) != 0:
+                            counter += 1
+                if counter != 0:
+                    updated_devicetype_list.append(item)
+                else:
+                    up_to_date_devicetype_list.append(item)
+
+        #Generates the output report summary
+        file_loader = FileSystemLoader('/opt/netbox/netbox/scripts/netbox_script/templates')
+        env = Environment(loader=file_loader)
+        template = env.get_template('devicetype_import_report.j2')
+        context = {
+            'in_library_list': in_library_list,
+            'not_in_library_list': not_in_library_list,
+            'imported_devicetype_list': imported_devicetype_list,
+            'updated_devicetype_list': updated_devicetype_list,
+            'up_to_date_devicetype_list': up_to_date_devicetype_list,
+            'updated_interfacetemplate_list': updated_interfacetemplate_list,
+            'deleted_interfacetemplate_list': deleted_interfacetemplate_list,
+            'imported_interfacetemplate_list': imported_interfacetemplate_list,
+            'updated_consoleporttemplate_list': updated_consoleporttemplate_list,
+            'deleted_consoleporttemplate_list': deleted_consoleporttemplate_list,
+            'imported_consoleporttemplate_list': imported_consoleporttemplate_list,
+            'updated_powerporttemplate_list': updated_powerporttemplate_list,
+            'deleted_powerporttemplate_list': deleted_powerporttemplate_list,
+            'imported_powerporttemplate_list': imported_powerporttemplate_list,
+        }
+        output = template.render(context)
+        return output

--- a/scripts/library/device_type_handler.py
+++ b/scripts/library/device_type_handler.py
@@ -1,0 +1,427 @@
+"""
+This script is a subcomponent of the main script - device_type_provisioning.py
+
+Author: Kenneth Acar Garcia
+Email: kenneth[.]acar[.]garcia[@]gmail[.]com
+"""
+
+import yaml
+from dcim.models import DeviceType, Manufacturer, InterfaceTemplate, PowerPortTemplate, ConsolePortTemplate
+
+class DeviceTypeHandler(object):
+    '''
+    Custom class to handle different types of operation for DeviceType object and its related objects
+    '''
+    def __init__(
+        self,
+        manufacturer: str, #DeviceType manufacturer from user uploaded yaml file
+        part_number: str, #DeviceType model from user uploaded yaml file
+        yaml_template: str = None, #Yaml template from NetBox devicetype-library
+        devicetype_obj: DeviceType = None, #DeviceType object model for importing or updating
+        manufacturer_obj: Manufacturer = None, #Manufacturer object model for importing or allocation
+        update_existing_record: bool = False, #Allow updating existing record for any difference with devicetype library template
+    ) -> None:
+        
+        self.manufacturer = manufacturer
+        self.part_number = part_number
+        if yaml_template:
+            self.dict_template = yaml.safe_load(yaml_template)
+        else:
+            self.dict_template = yaml_template
+        self.devicetype_obj = devicetype_obj
+        self.manufacturer_obj = manufacturer_obj
+        self.imported_interfacetemplates: list[str] = [] #Placeholder of imported InterfaceTemplate object list
+        self.updated_interfacetemplates: list[str] = [] #Placeholder of updated InterfaceTemplate object list
+        self.deleted_interfacetemplates: list[str] = [] #Placeholder of deleted InterfaceTemplate object list
+        self.imported_powerporttemplates: list[str] = [] #Placeholder of imported PowerPortTemplate object list
+        self.updated_powerporttemplates: list[str] = [] #Placeholder of updated PowerPortTemplate object list
+        self.deleted_powerporttemplates: list[str] = [] #Placeholder of deleted PowerPortTemplate object list
+        self.imported_consoleporttemplates: list[str] = [] #Placeholder of imported ConsolePortTemplate object list
+        self.updated_consoleporttemplates: list[str] = [] #Placeholder of updated ConsolePortTemplate object list
+        self.deleted_consoleporttemplates: list[str] = [] #Placeholder of deleted ConsolePortTemplate object list
+        self.update_existing_record = update_existing_record #Placeholder of user option in updating existing records
+        self.operation_mode: bool = None #Placeholder of operation mode triggered for this object. True if import and False if update
+    
+    def _search_device_type(self) -> bool:
+        '''
+        Private method to search the part_number in existing DeviceType records.
+        Returns True if part_number is found and False if not.
+        '''
+        try:
+            DeviceType.objects.get(part_number=self.part_number)
+            return True
+        except DeviceType.DoesNotExist:
+            return False
+
+    def _search_manufacturer(self) -> bool:
+        '''
+        Private method to search the vendor in existing Manufacturer records.
+        Returns True if vendor is found and False if not.
+        '''
+        try:
+            Manufacturer.objects.get(name=self.manufacturer)
+            return True
+        except Manufacturer.DoesNotExist:
+            return False
+    
+    def _import_manufacturer(self) -> None:
+        '''
+        Private method to import Manufacture object if vendor not found in existing records.
+        '''
+        self.manufacturer_obj = Manufacturer(
+            name = self.manufacturer
+        )
+        self.manufacturer_obj.save()
+
+    def _delete_interface_template(self, interfacetemplates: list[InterfaceTemplate]) -> None:
+        '''
+        Private method to delete existing InterfaceTemplate object which is not matching rom the reference DeviceType library template.
+        '''
+        for_deleting_list = []
+        queryable_template_list = [ interface['name'] for interface in self.dict_template['interfaces'] ]
+        for interface in interfacetemplates:
+            if interface.name not in queryable_template_list:
+                for_deleting_list.append(interface)
+
+        for interface in for_deleting_list:
+            interface.delete()
+            self.deleted_interfacetemplates.append(f"{interface.device_type.model}: {interface.name}")
+       
+    def _update_interface_template(self) -> None:
+        '''
+        Private method to update existing InterfaceTemplate object or import if missing from the reference DeviceType library template.
+        '''
+        #Fetch all related InterfaceTemplate objects to the matching DeviceType object.
+        existing_obj_list = InterfaceTemplate.objects.filter(device_type=self.devicetype_obj)
+        
+        #Transform list of InterfaceTemplate objects into python dict format for easier comparison logic.
+        existing_obj_list_to_dict = { obj.name: {'type': obj.type, 'mgmt_only': obj.mgmt_only} for obj in existing_obj_list }
+        
+        #Placeholder of existing InterfaceTemplate objects in dict format for updating.
+        for_updating_list = []
+        
+        #Placeholder of InterfaceTemplate templates in dict format for importing.
+        for_importing_list = []
+        
+        #Iterate the list of interfaces in devicetype-library template and match it to the existing list of InterfaceTemplate objects.
+        for interface in self.dict_template['interfaces']:
+            if interface['name'] in existing_obj_list_to_dict:
+                diff_count = 0
+                for param in ['type', 'mgmt_only']:
+                    if param in interface:
+                        if existing_obj_list_to_dict[interface['name']][param] != interface[param]:
+                            diff_count += 1
+                    else:
+                        if existing_obj_list_to_dict[interface['name']][param]:
+                            diff_count += 1
+                if diff_count != 0:
+                    for_updating_list.append(interface)
+            else:
+                for_importing_list.append(interface)
+        
+        #Iterate the placeholder of existing InterfaceTemplate objects list for record updating in database
+        for interface in for_updating_list:
+            existing_obj_to_update = InterfaceTemplate.objects.get(
+                device_type = self.devicetype_obj,
+                name = interface['name'],
+            )
+            
+            existing_obj_to_update.type = interface['type']
+            if 'mgmt_only' in interface:
+                existing_obj_to_update.mgmt_only = interface['mgmt_only']
+            else:
+                existing_obj_to_update.mgmt_only = False
+            existing_obj_to_update.save()
+            self.updated_interfacetemplates.append(f"{existing_obj_to_update.device_type.model}: {existing_obj_to_update.name}")
+
+        #Import any item in placeholder of existing InterfaceTemplate objects list using self._import_interface_template private method
+        if for_importing_list != []:
+            self._import_interface_template(
+                interfaces_dict_list = for_importing_list,
+                # devicetype_obj = self.devicetype_obj
+            )
+
+        #Trigger delete private method if total count is different between template interface list and latest interface record 
+        template_count = len(self.dict_template['interfaces'])
+        latest_interfacetemplates = InterfaceTemplate.objects.filter(device_type=self.devicetype_obj)
+        existing_count = len(latest_interfacetemplates)
+        if template_count != existing_count:
+            self._delete_interface_template(latest_interfacetemplates)
+
+    def _import_interface_template(
+            self,
+            interfaces_dict_list: dict,
+    ) -> None:
+        '''
+        Private method to import InterfaceTemplate objects from the reference DeviceType library template.
+        '''
+        for_importing_list = []
+        for interface in interfaces_dict_list:
+        # for interface in self.dict_template['interfaces']:
+            if 'mgmt_only' in interface:
+                for_importing_list.append(
+                    InterfaceTemplate(
+                        device_type = self.devicetype_obj,
+                        name = interface['name'],
+                        type = interface['type'],
+                        mgmt_only = interface['mgmt_only']
+                    )
+                )
+            else:
+                for_importing_list.append(
+                    InterfaceTemplate(
+                        device_type = self.devicetype_obj,
+                        name = interface['name'],
+                        type = interface['type'],
+                    )
+                )
+        for interface in for_importing_list:
+            interface.save()
+            self.imported_interfacetemplates.append(f"{interface.device_type.model}: {interface.name}")
+
+    def _delete_consoleport_template(self, consoleporttemplates: list[ConsolePortTemplate]) -> None:
+        '''
+        Private method to delete existing ConsolePortTemplate object which is not matching rom the reference DeviceType library template.
+        '''
+        for_deleting_list = []
+        queryable_template_list = [ consoleport['name'] for consoleport in self.dict_template['console-ports'] ]
+        for consoleport in consoleporttemplates:
+            if consoleport.name not in queryable_template_list:
+                for_deleting_list.append(consoleport)
+
+        for consoleport in for_deleting_list:
+            consoleport.delete()
+            self.deleted_consoleporttemplates.append(f"{consoleport.device_type.model}: {consoleport.name}")
+
+    def _update_consoleport_template(self) -> None:
+        '''
+        Private method to update existing ConsolePortTemplate object or import if missing from the reference DeviceType library template.
+        '''
+        #Fetch all related ConsolePortTemplate objects to the matching DeviceType object.
+        existing_obj_list = ConsolePortTemplate.objects.filter(device_type=self.devicetype_obj)
+        
+        #Transform list of ConsolePortTemplate objects into python dict format for easier comparison logic.
+        existing_obj_list_to_dict = { obj.name: { 'type': obj.type } for obj in existing_obj_list }
+        
+        #Placeholder of existing ConsolePortTemplate objects in dict format for updating.
+        for_updating_list = []
+        
+        #Placeholder of ConsolePortTemplate templates in dict format for importing.
+        for_importing_list = []
+        
+        #Iterate the list of console-ports in devicetype-library template and match it to the existing list of ConsolePortTemplate objects.
+        for consoleport in self.dict_template['console-ports']:
+            if consoleport['name'] in existing_obj_list_to_dict:                
+                for param in ['type']:
+                    if existing_obj_list_to_dict[consoleport['name']][param] != consoleport[param]:
+                        for_updating_list.append(consoleport)
+            else:
+                for_importing_list.append(consoleport)
+        
+        #Iterate the placeholder of existing ConsolePortTemplate objects list for record updating in database
+        for consoleport in for_updating_list:
+            existing_obj_to_update = ConsolePortTemplate.objects.get(
+                device_type = self.devicetype_obj,
+                name = consoleport['name'],
+            )
+            
+            existing_obj_to_update.type = consoleport['type']
+            existing_obj_to_update.save()
+            self.updated_consoleporttemplates.append(f"{existing_obj_to_update.device_type.model}: {existing_obj_to_update.name}")
+
+        #Import any item in placeholder of existing ConsolePortTemplate objects list using self._import_consoleport_template private method
+        if for_importing_list != []:
+            self._import_consoleport_template(
+                consoleports_dict_list = for_importing_list,
+            )
+
+        #Trigger delete private method if total count is different between template consoleport list and latest consoleport record 
+        template_count = len(self.dict_template['console-ports'])
+        latest_consoleporttemplates = ConsolePortTemplate.objects.filter(device_type=self.devicetype_obj)
+        existing_count = len(latest_consoleporttemplates)
+        if template_count != existing_count:
+            self._delete_consoleport_template(latest_consoleporttemplates)
+
+    def _import_consoleport_template(
+            self,
+            consoleports_dict_list: dict,
+    ) -> None:
+        '''
+        Method to import ConsolePortTemplate objects from template
+        '''
+        for_importing_list = []
+        for consoleport in consoleports_dict_list:
+            for_importing_list.append(
+                ConsolePortTemplate(
+                    device_type = self.devicetype_obj,
+                    name = consoleport['name'],
+                    type = consoleport['type'],
+                )
+            )
+        for consoleport in for_importing_list:
+            consoleport.save()
+            self.imported_consoleporttemplates.append(f"{consoleport.device_type.model}: {consoleport.name}")
+
+    def _delete_powerport_template(self, powerporttemplates: list[PowerPortTemplate]) -> None:
+        '''
+        Private method to delete existing PowerPortTemplate object which is not matching rom the reference DeviceType library template.
+        '''
+        for_deleting_list = []
+        queryable_template_list = [ powerport['name'] for powerport in self.dict_template['power-ports'] ]
+        for powerport in powerporttemplates:
+            if powerport.name not in queryable_template_list:
+                for_deleting_list.append(powerport)
+
+        for powerport in for_deleting_list:
+            powerport.delete()
+            self.deleted_powerporttemplates.append(f"{powerport.device_type.model}: {powerport.name}")
+
+    def _update_powerport_template(self) -> None:
+        '''
+        Private method to update existing PowerPortTemplate object or import if missing from the reference DeviceType library template.
+        '''
+        #Fetch all related PowerPortTemplate objects to the matching DeviceType object.
+        existing_obj_list = PowerPortTemplate.objects.filter(device_type=self.devicetype_obj)
+        
+        #Transform list of PowerPortTemplate objects into python dict format for easier comparison logic.
+        existing_obj_list_to_dict = { obj.name: {
+             'type': obj.type,
+             'allocated_draw': obj.allocated_draw,
+             'maximum_draw': obj.maximum_draw,
+        } for obj in existing_obj_list }
+        
+        #Placeholder of existing PowerPortTemplate objects in dict format for updating.
+        for_updating_list = []
+        
+        #Placeholder of PowerPortTemplate templates in dict format for importing.
+        for_importing_list = []
+        
+        #Iterate the list of power-ports in devicetype-library template and match it to the existing list of PowerPortTemplate objects.
+        for powerport in self.dict_template['power-ports']:
+            if powerport['name'] in existing_obj_list_to_dict:                
+                for param in ['type', 'allocated_draw', 'maximum_draw']:
+                    if existing_obj_list_to_dict[powerport['name']][param] != powerport[param]:
+                        for_updating_list.append(powerport)
+            else:
+                for_importing_list.append(powerport)
+        
+        #Iterate the placeholder of existing PowerPortTemplate objects list for record updating in database
+        for powerport in for_updating_list:
+            existing_obj_to_update = PowerPortTemplate.objects.get(
+                device_type = self.devicetype_obj,
+                name = powerport['name'],
+            )
+            
+            existing_obj_to_update.type = powerport['type']
+            existing_obj_to_update.allocated_draw = powerport['allocated_draw']
+            existing_obj_to_update.maximum_draw = powerport['maximum_draw']
+            existing_obj_to_update.save()
+            self.updated_powerporttemplates.append(f"{existing_obj_to_update.device_type.model}: {existing_obj_to_update.name}")
+
+        #Import any item in placeholder of existing PowerPortTemplate objects list using self._import_powerport_template private method
+        if for_importing_list != []:
+            self._import_powerport_template(
+                powerports_dict_list = for_importing_list,
+            )
+
+        #Trigger delete private method if total count is different between template powerport list and latest powerport record 
+        template_count = len(self.dict_template['power-ports'])
+        latest_powerporttemplates = PowerPortTemplate.objects.filter(device_type=self.devicetype_obj)
+        existing_count = len(latest_powerporttemplates)
+        if template_count != existing_count:
+            self._delete_powerport_template(latest_powerporttemplates)
+
+    def _import_powerport_template(
+            self,
+            powerports_dict_list: dict,
+    ) -> None:
+        '''
+        Private method to import PowerPortTemplate objects from template
+        '''
+        for_importing_list = []
+        for powerport in powerports_dict_list:
+            for_importing_list.append(
+                PowerPortTemplate(
+                    device_type = self.devicetype_obj,
+                    name = powerport['name'],
+                    type = powerport['type'],
+                    allocated_draw = powerport['allocated_draw'],
+                    maximum_draw = powerport['maximum_draw'],
+                )
+            )
+        for powerport in for_importing_list:
+            powerport.save()
+            self.imported_powerporttemplates.append(f"{powerport.device_type.model}: {powerport.name}")
+
+    def _update_record(self) -> None:
+        '''
+        Private method to update existing DeviceType object from the reference DeviceType library template.
+        '''
+        self.devicetype_obj = DeviceType.objects.get(part_number=self.part_number)
+        existing_obj_dict = yaml.safe_load(self.devicetype_obj.to_yaml())
+        params = [
+            'manufacturer',
+            'model',
+            'slug',
+            'u_height',
+            'is_full_depth',
+        ]
+        for_updating_list = []
+        for param in params:
+            if existing_obj_dict[param] != self.dict_template[param]:
+                for_updating_list.append(param)
+        for param in for_updating_list:
+            if param == 'manufacturer':
+                self.devicetype_obj.manufacturer = Manufacturer.objects.get(name=self.manufacturer)
+            elif param == 'model':
+                self.devicetype_obj.model = self.dict_template[param]
+            elif param == 'slug':
+                self.devicetype_obj.slug = self.dict_template[param]
+            elif param == 'u_height':
+                self.devicetype_obj.u_height = self.dict_template[param]
+            elif param == 'is_full_depth':
+                self.devicetype_obj.is_full_depth = self.dict_template[param]
+        if for_updating_list != []:
+            self.devicetype_obj.save()
+        self._update_interface_template()
+        self._update_consoleport_template()
+        self._update_powerport_template()
+        self.operation_mode = False
+
+    def import_record(self) -> DeviceType:
+        '''
+        Method to import DeviceType object from the reference DeviceType library template.
+        '''
+        if not self._search_device_type():
+            if not self._search_manufacturer():
+                self._import_manufacturer()
+            else:
+                self.manufacturer_obj = Manufacturer.objects.get(name=self.manufacturer)
+            self.devicetype_obj = DeviceType(
+                manufacturer = self.manufacturer_obj,
+                model = self.dict_template['model'],
+                part_number = self.part_number,
+                slug = self.dict_template['slug'],
+                u_height = self.dict_template['u_height'],
+                is_full_depth = self.dict_template['is_full_depth'],
+            )
+            self.devicetype_obj.save()
+
+            self._import_interface_template(
+                interfaces_dict_list = self.dict_template['interfaces'],
+            )
+
+            self._import_consoleport_template(
+                consoleports_dict_list = self.dict_template['console-ports'],
+            )
+
+            self._import_powerport_template(
+                powerports_dict_list = self.dict_template['power-ports'],
+            )
+            self.operation_mode = True
+        else:
+            if self.update_existing_record:
+                self._update_record()
+
+    def __str__(self) -> str:
+        return f"{self.manufacturer}: {self.part_number}"

--- a/scripts/templates/devicetype_import_report.j2
+++ b/scripts/templates/devicetype_import_report.j2
@@ -1,0 +1,97 @@
+{%- if in_library_list %}
+[{{ in_library_list|count }}] Found in Netbox devicetype-library:
+{%- for i in in_library_list %}
+{{ i }}
+{%- endfor %}
+{%- endif %}
+{%- if not_in_library_list %}
+
+[{{ not_in_library_list|count }}] Not found in Netbox devicetype-library:
+{%- for i in not_in_library_list %}
+{{ i }}
+{%- endfor %}
+{%- endif %}
+{%- if imported_devicetype_list %}
+
+[{{ imported_devicetype_list|count }}] Imported devicetype object records:
+{%- for i in imported_devicetype_list %}
+{{ i }}
+{%- endfor %}
+{%- endif %}
+{%- if updated_devicetype_list %}
+
+[{{ updated_devicetype_list|count }}] Updated Existing devicetype object records:
+{%- for i in updated_devicetype_list %}
+{{ i }}
+{%- endfor %}
+{%- endif %}
+{%- if up_to_date_devicetype_list %}
+
+[{{ up_to_date_devicetype_list|count }}] Existing devicetype object records matching devicetype-library template:
+{%- for i in up_to_date_devicetype_list %}
+{{ i }}
+{%- endfor %}
+{%- endif %}
+{%- if updated_interfacetemplate_list %}
+
+[{{ updated_interfacetemplate_list|count }}] Updated interface template records:
+{%- for i in updated_interfacetemplate_list %}
+{{ i }}
+{%- endfor %}
+{%- endif %}
+{%- if deleted_interfacetemplate_list %}
+
+[{{ deleted_interfacetemplate_list|count }}] Deleted interface template records:
+{%- for i in deleted_interfacetemplate_list %}
+{{ i }}
+{%- endfor %}
+{%- endif %}
+{%- if imported_interfacetemplate_list %}
+
+[{{ imported_interfacetemplate_list|count }}] Imported interface template records:
+{%- for i in imported_interfacetemplate_list %}
+{{ i }}
+{%- endfor %}
+{%- endif %}
+{%- if updated_consoleporttemplate_list %}
+
+[{{ updated_consoleporttemplate_list|count }}] Updated consoleport template records:
+{%- for i in updated_consoleporttemplate_list %}
+{{ i }}
+{%- endfor %}
+{%- endif %}
+{%- if deleted_consoleporttemplate_list %}
+
+[{{ deleted_consoleporttemplate_list|count }}] Deleted consoleport template records:
+{%- for i in deleted_consoleporttemplate_list %}
+{{ i }}
+{%- endfor %}
+{%- endif %}
+{%- if imported_consoleporttemplate_list %}
+
+[{{ imported_consoleporttemplate_list|count }}] Imported consoleport template records:
+{%- for i in imported_consoleporttemplate_list %}
+{{ i }}
+{%- endfor %}
+{%- endif %}
+{%- if updated_powerporttemplate_list %}
+
+[{{ updated_powerporttemplate_list|count }}] Updated powerport template records:
+{%- for i in updated_powerporttemplate_list %}
+{{ i }}
+{%- endfor %}
+{%- endif %}
+{%- if deleted_powerporttemplate_list %}
+
+[{{ deleted_powerporttemplate_list|count }}] Deleted powerport template records:
+{%- for i in deleted_powerporttemplate_list %}
+{{ i }}
+{%- endfor %}
+{%- endif %}
+{%- if imported_powerporttemplate_list %}
+
+[{{ imported_powerporttemplate_list|count }}] Imported powerport template records:
+{%- for i in imported_powerporttemplate_list %}
+{{ i }}
+{%- endfor %}
+{%- endif %}


### PR DESCRIPTION
This script allows you to import or update exising devicetype record from Netbox's official [devicetype-library git repository](https://github.com/netbox-community/devicetype-library).
For more details and instruction, you may check this [git repo](https://github.com/kagarcia1618/netbox_custom_script).

Note: This scripts has dependency to two other folder found in the directory below:
- `reports/scripts/library`
- `reports/scripts/template`

`library `folder contains the custom class script `device_type_handler.py` to compliment the main script `device_type_provisioning.py`.
`template `folder contains the jinja2 template file for generating the script report summary output.