### PR TITLE
Create export-rearports-for-adding-details.txt

### DIFF
--- a/export_templates/export-rearports-for-adding-details.txt
+++ b/export_templates/export-rearports-for-adding-details.txt
@@ -1,0 +1,11 @@
+##Why? We use Label and description of rear ports to mark in where which room a port ends.
+##After adding the information it can be reimported again thanks to the recently added edit functionality.
+
+{%- for device in queryset %}
+##################################
+###Rearports of "{{device.name}}" @ Rack {{device.rack}} - {{device.location}} in {{device.site}}
+###Description: More Information (Wall/Floor mounted etc.),Label = Room Number
+id,name,description,label
+{%- for rearport in device.rearports.all() %}
+{{rearport.id}},{{rearport.name}},{{rearport.description}},{{rearport.label}}
+{%- endfor %}{%- endfor %}


### PR DESCRIPTION
Why? We use Label and description of rear ports to mark in where which room a port ends. After adding the information it can be reimported again thanks to the recently added edit functionality.


Example:
id,name,description,label
1337,1,Wallmounted,R4711
1338,1,In Ceiling ,Floor 0815