### PR TITLE
Fix import of AbortScript

### DIFF
--- a/scripts/renumber.py
+++ b/scripts/renumber.py
@@ -7,7 +7,8 @@ BACKUP YOUR DATABASE BEFORE USING!
 """
 
 from ipam.models import VRF, Prefix, IPAddress, IPRange
-from extras.scripts import Script, AbortScript, ObjectVar, IPAddressWithMaskVar, BooleanVar
+from extras.scripts import Script, ObjectVar, IPAddressWithMaskVar, BooleanVar
+from utilities.exceptions import AbortScript
 
 class Renumber(Script):
     class Meta:


### PR DESCRIPTION
(It was never officially available under extras.scripts, but since Netbox v4.1.0 / commit d3a3a6ba, it has been removed)